### PR TITLE
docker-kali-rolling Fix security.kali.org 404 not found error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,7 @@ FROM kalilinux/kali-rolling
 MAINTAINER steev@kali.org
 
 RUN echo "deb http://http.kali.org/kali kali-rolling main contrib non-free" > /etc/apt/sources.list && \
-echo "deb-src http://http.kali.org/kali kali-rolling main contrib non-free" >> /etc/apt/sources.list && \
-echo "deb http://security.kali.org/kali-security kali-rolling/updates main contrib non-free" >> /etc/apt/sources.list && \
-echo "deb-src http://security.kali.org/kali-security kali-rolling/updates main contrib non-free" >> /etc/apt/sources.list
+echo "deb-src http://http.kali.org/kali kali-rolling main contrib non-free" >> /etc/apt/sources.list 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get -y update && apt-get -y dist-upgrade && apt-get clean
 


### PR DESCRIPTION
According to your official statement , http.kali.org alone is well enough , since there would be some 404 error related to security.kali.org repository on recent builds , it seems remove the security.kali.org may be a simple solution

Tested on below recently

https://hub.docker.com/r/lxj616/kali-linux-docker-rolling/builds/bbyka339t6va4sjdeggunng/

BTW maybe fix security.kali.org repository would be better than just remove that repository 
